### PR TITLE
Disable serial2, fix bltouch pin

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -109,7 +109,7 @@
  * Currently Ethernet (-2) is only supported on Teensy 4.1 boards.
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT_2 3
+//#define SERIAL_PORT_2 3
 
 /**
  * This setting determines the communication speed of the printer.

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
@@ -79,7 +79,7 @@
 #define Y_STOP_PIN                          PA7
 #define Z_STOP_PIN                          PA5
 
-#define Z_MIN_PROBE_PIN                     PA5   // BLTouch IN
+#define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
 
 //
 // Filament Runout Sensor


### PR DESCRIPTION
### Description

Disable SERIAL2 as the pins it uses conflict with the LCD serial pins.
Fix a BL Touch pin that is defined incorrectly.

### Benefits

Small minor issues found during testing, may or may not cause LCD Issues.
BL Touch can be used with the pin fix.

### Configurations

Part of the PR changes.

### Related Issues

None that I know of.